### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.2] - 2025-09-04
+
+### 🚀 Features
+
+- Add multiple channel providers
 ## [0.0.1] - 2025-09-02
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "suck"
 description = "Suck data up through a channel"
 authors = ["Callum Leslie <git@cleslie.uk>"]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 documentation = "https://docs.rs/suck"
 homepage = "https://github.com/callumio/suck"


### PR DESCRIPTION



## 🤖 New release

* `suck`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2] - 2025-09-04

### 🚀 Features

- Add multiple channel providers
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).