### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.3] - 2026-03-04
+
+### 🚀 Features
+
+- Remove closed flag from ChannelState
+- Add internal constructor for `Sucker`/`Sourcer`
+- Implement asynchronous channel support with tokio integration
+
+### 🐛 Bug Fixes
+
+- Correct toolchain in flake
+
+### 🚜 Refactor
+
+- Move traits to sync module and update imports
+- Reorganize channel modules and implement async/sync structures
+
+### 🧪 Testing
+
+- Set_mut tests
+- Increase code coverage of failure paths
+
+### ⚙️ Miscellaneous Tasks
+
+- Remove unused traits module
+- Reorganize module exports for async and sync features
 ## [0.0.2] - 2025-09-04
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "suck"
 description = "Suck data up through a channel"
 authors = ["Callum Leslie <git@cleslie.uk>"]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 documentation = "https://docs.rs/suck"
 homepage = "https://github.com/callumio/suck"


### PR DESCRIPTION



## 🤖 New release

* `suck`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3] - 2026-03-04

### 🚀 Features

- Remove closed flag from ChannelState
- Add internal constructor for `Sucker`/`Sourcer`
- Implement asynchronous channel support with tokio integration

### 🐛 Bug Fixes

- Correct toolchain in flake

### 🚜 Refactor

- Move traits to sync module and update imports
- Reorganize channel modules and implement async/sync structures

### 🧪 Testing

- Set_mut tests
- Increase code coverage of failure paths

### ⚙️ Miscellaneous Tasks

- Remove unused traits module
- Reorganize module exports for async and sync features
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).